### PR TITLE
Update 0701_2.html with additional sound effects

### DIFF
--- a/0701_2.html
+++ b/0701_2.html
@@ -962,6 +962,16 @@
       src="workspace/ビープ音4.mp3"
       preload="auto"
     ></audio>
+    <audio
+      id="sound-drumroll"
+      src="workspace/ドラムロール.mp3"
+      preload="auto"
+    ></audio>
+    <audio
+      id="sound-rollfinish"
+      src="workspace/ロールの閉め.mp3"
+      preload="auto"
+    ></audio>
     <!-- リセットボタン -->
     <div class="reset-btns-fixed">
       <button class="event-reset-btn" onclick="resetEvents()">
@@ -1564,6 +1574,7 @@
         let rounds = 0;
         let totalRounds = 18 + finalIdx; // 最低3周＋ランダム
         let speed = 80;
+        playSound('sound-drumroll');
         function spin() {
           // remove all active
           for (let i = 0; i < rList.children.length; i++) {
@@ -1576,6 +1587,7 @@
             rounds++;
             if (rounds > totalRounds - 7) speed += 25; // 減速
             setTimeout(spin, speed);
+            playSound('sound-rollfinish');
           } else {
             // 決定
             let decidedIdx = totalRounds % rouletteCandidates.length;


### PR DESCRIPTION
## Summary
- add missing `sound-drumroll` and `sound-rollfinish` audio elements
- trigger new sounds during the AI roulette animation

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6863481d4f308332b9c7aa1aa3abcad6